### PR TITLE
parserOptions to .eslintrc to avoid parsing error when building

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,9 @@
   "ecmaFeatures": {
     "modules": true
   },
+  "parserOptions": {
+    "sourceType": module
+  },
   "env": {
     "browser": true,
     "es6": true


### PR DESCRIPTION
I was getting this error when building with gulp:

`1:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'`

Added change to .eslintrc and build now completes without errors.
